### PR TITLE
Prevent voting process with `start_date` > `end_date`

### DIFF
--- a/components/pages/votes/new/options-date-selector.tsx
+++ b/components/pages/votes/new/options-date-selector.tsx
@@ -76,6 +76,10 @@ export const OptionDateSelector = ({
 
     setInvalidStartDate(invalidDate)
 
+    if(endDate < startDate) {
+      setEndDate(addOffsetToDate(new Date(startDate), 7))
+    }
+
     onChangeDate(
       {
         start: startDate,

--- a/components/pages/votes/new/options.tsx
+++ b/components/pages/votes/new/options.tsx
@@ -28,7 +28,7 @@ export const FormOptions = () => {
   const periodRef = useRef<IProcessPeriod>()
 
   const valid = () => {
-    return startDate && endDate && !invalidDate
+    return startDate && endDate && !invalidDate && startDate < endDate
   }
 
   const onSubmit = () => {


### PR DESCRIPTION
Modified the UI in order to prevent creating a new process where the end date is prior to start date