### PR TITLE
[VPLZ-217] Improved voting detail page look

### DIFF
--- a/components/blocks/dashed-link.tsx
+++ b/components/blocks/dashed-link.tsx
@@ -41,6 +41,7 @@ const LinkContainer = styled(FlexContainer)`
 `
 
 const LinkText = styled(SectionText)`
+  font-size: 14px;
   color: ${({ theme }) => theme.textAccent1};
   overflow: hidden;
   margin: 12px 10px 12px 0;

--- a/components/blocks/process-status-label.tsx
+++ b/components/blocks/process-status-label.tsx
@@ -32,6 +32,7 @@ export const ProcessStatusLabel = ({status}: IProcessStatusLabelProps) => {
 }
 
 const BaseProcessStatusLabel = styled.span`
+  box-shadow: rgba(180, 193, 228, 0.35) 0px 3px 3px;
   border-radius: 10px;
   height: 16px;
   padding: 2px 8px;

--- a/components/elements/line.tsx
+++ b/components/elements/line.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+
+type LineProps = {
+  color?: string,
+}
+
+export const Line = styled.hr<{color?: string}>`
+  color: ${({ color, theme }) => (color ? color : theme.lightBorder)};
+`

--- a/components/pages/dashboard/vote-detail/index.tsx
+++ b/components/pages/dashboard/vote-detail/index.tsx
@@ -2,31 +2,23 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import {
-  IProcessDetails,
   DigestedProcessResults,
+  IProcessDetails,
+  VochainProcessStatus,
   VotingApi,
   EntityMetadata,
 } from 'dvote-js'
-import { VochainProcessStatus } from 'dvote-js'
 
 import { colors } from 'theme/colors'
-import {
-  VOTING_AUTH_FORM_PATH,
-  VOTING_AUTH_LINK_PATH,
-  VOTING_AUTH_MNEMONIC_PATH,
-} from '@const/routes'
+import { VOTING_AUTH_FORM_PATH, VOTING_AUTH_LINK_PATH, VOTING_AUTH_MNEMONIC_PATH } from '@const/routes'
 import RouterService from '@lib/router'
 import { Question } from '@lib/types'
 
-import {
-  FlexContainer,
-  FlexJustifyContent,
-  FlexAlignItem,
-  FlexWrap
-} from '@components/elements/flex'
-import { SectionText, SectionTitle } from '@components/elements/text'
-import { Grid, Column } from '@components/elements/grid'
+import { FlexAlignItem, FlexContainer, FlexJustifyContent, FlexWrap } from '@components/elements/flex'
+import { SectionText, SectionTitle, TextSize } from '@components/elements/text'
+import { Column, Grid } from '@components/elements/grid'
 import { Button } from '@components/elements/button'
+import { Line } from '@components/elements/line'
 import { PageCard } from '@components/elements/cards'
 import { DashedLink } from '@components/blocks/dashed-link'
 import { ProcessStatusLabel } from '@components/blocks/process-status-label'
@@ -228,14 +220,18 @@ export const ViewDetail = ({
         </Column>
       </Grid>
 
+      <Line color={colors.lightBorder} />
+
       <Grid>
         <Column md={9} sm={12}>
           <SectionContainer>
             <If condition={!linkCensus}>
               <Then>
-                <SectionText color={colors.blueText}>
-                  {i18n.t('vote_detail.vote_link')}
-                </SectionText>
+                <SectionSpacer>
+                  <SectionText color={colors.blueText} size={TextSize.Big}>
+                    {i18n.t('vote_detail.link')}
+                  </SectionText>
+                </SectionSpacer>
                 <DashedLink link={voteLink} />
               </Then>
               <Else>
@@ -271,10 +267,16 @@ export const ViewDetail = ({
             </If>
           </SectionContainer>
 
+          <SectionSpacer>
+            <SectionText color={colors.blueText} size={TextSize.Big}>
+              {i18n.t('vote_detail.details')}
+            </SectionText>
+          </SectionSpacer>
+
           <SectionContainer>
             <DateContainer>
               <ProcessStatusLabel status={status}></ProcessStatusLabel>
-              <div>{dateDiffStr}</div>
+              <DateDiffText>{dateDiffStr}</DateDiffText>
             </DateContainer>
           </SectionContainer>
 
@@ -287,9 +289,11 @@ export const ViewDetail = ({
           </SectionContainer>
 
           <div>
-            <SectionText color={colors.blueText}>
-              {i18n.t('vote_detail.vote_results')}
-            </SectionText>
+            <SectionSpacer>
+              <SectionText color={colors.blueText} size={TextSize.Big}>
+                {i18n.t('vote_detail.results')}
+              </SectionText>
+            </SectionSpacer>
 
             {process?.metadata && process?.metadata?.questions.map(
               (question: Question, index: number) => (
@@ -333,8 +337,22 @@ const ButtonContainer = styled.div`
 const SectionContainer = styled.div`
   margin-bottom: 16px;
 `
+const SectionSpacer = styled.div`
+  margin-top: 28px;
+`
 const DateContainer = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+`
+const TitleText = styled.div`
+  font-size: 20px;
+  font-weight: 500;
+`
+const DescriptionText = styled.div`
+  text-align: justify;
+  text-justify: inter-word;
+`
+const DateDiffText = styled.div`
+  font-style: italic;
 `

--- a/i18n/locales/ca.json
+++ b/i18n/locales/ca.json
@@ -458,13 +458,14 @@
     },
     "vote_detail": {
         "cancel_vote": "Cancel·la la votació",
+        "details": "Detalls",
         "end_vote": "Finalitza la votació",
         "generate_pdf": "",
         "generate_pdf_with_results": "Crea un PDF amb els resultats",
+        "link": "Enllaç",
+        "results": "Resultats",
         "view_and_manage_the_status_of_the_process": "Visualitza i gestiona l'estat del procés",
-        "vote_details": "Detalls del procés de votació",
-        "vote_link": "Enllaç del procés de votació",
-        "vote_results": "Resultats del procés votació"
+        "vote_details": "Detalls del procés de votació"
     },
     "vote_question_card": {
         "no_results_available": "Resultats no estan disponibles",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -460,13 +460,14 @@
     },
     "vote_detail": {
         "cancel_vote": "Cancel vote",
+        "details": "Details",
         "end_vote": "End vote",
         "generate_pdf": "Generate PDF",
         "generate_pdf_with_results": "Generate a PDF with results",
+        "link": "Link",
+        "results": "Results",
         "view_and_manage_the_status_of_the_process": "View and manage the status of the process",
-        "vote_details": "Vote details",
-        "vote_link": "Voting link",
-        "vote_results": "Vote results"
+        "vote_details": "Vote details"
     },
     "vote_question_card": {
         "no_results_available": "No results available",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -460,13 +460,14 @@
     },
     "vote_detail": {
         "cancel_vote": "Cancelar la votación",
+        "details": "Detalles",
         "end_vote": "Finalitzar la votación",
         "generate_pdf": "",
         "generate_pdf_with_results": "Crear un PDF con los resultados",
+        "link": "Enlace",
+        "results": "Resultados",
         "view_and_manage_the_status_of_the_process": "Visualizar y gestionar el estado del proceso",
-        "vote_details": "Detalles de la votación",
-        "vote_link": "Enlace de la votación",
-        "vote_results": "Resultados de la votación"
+        "vote_details": "Detalles de la votación"
     },
     "vote_question_card": {
         "no_results_available": "Resultados no disponibles",


### PR DESCRIPTION
Added line between header and content
Added the 3 sections titles (Link, Detail, Results)
Simplified the texts: "Enllaç al procés de votació", "Detalls del procés de votació", "Resultats del procés de votació" a "Enllaç, Detalls, Resultats"
Unified the styles of 3 sections titles
Added italics to the "Finalitza d'aquí 297 dies" text
Added bottom padding in the "Generate PDF" card
Justified description text
Modified title with new style
Added vertical margin between "sections" (Link, Detail, Results)
Reduced the link text to `14px`
Added `box-shadow:rgba(180, 193, 228, 0.35) 0px 3px 3px` in the "Process Actiu" label