### PR TITLE
Multiple style fixes

### DIFF
--- a/components/blocks-v2/process-status-label.tsx
+++ b/components/blocks-v2/process-status-label.tsx
@@ -1,46 +1,68 @@
-import React from 'react'
-import { useTranslation } from 'react-i18next'
-import { VoteStatus } from '@lib/util'
-import { Tag } from '../elements-v2/tag'
-import { useUrlHash } from 'use-url-hash'
 import { useProcessWrapper } from '@hooks/use-process-wrapper'
 import { dateDiffStr, DateDiffType } from '@lib/date-moment'
+import { VoteStatus } from '@lib/util'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+import { useUrlHash } from 'use-url-hash'
+import { Tag } from '../elements-v2/tag'
 
 export const ProcessStatusLabel = () => {
   const { i18n } = useTranslation()
   const processId = useUrlHash().slice(1)
-  const { status, endDate, startDate } = useProcessWrapper(processId)
+  const { status, endDate, startDate, archived } = useProcessWrapper(processId)
   const endingInDiffString = dateDiffStr(DateDiffType.CountdownV2, endDate)
   const startingInDiffString = dateDiffStr(DateDiffType.CountdownV2, startDate)
+  const tags = []
   switch (status) {
     case VoteStatus.Active:
-      return (
-          <Tag
-            variant='success'
-            label={i18n.t('vote.ending_in') + ' ' + endingInDiffString}
-          >
-            {i18n.t('vote.active_vote')}
-          </Tag>
+      tags.push(
+        <Tag
+          variant='success'
+          key='active'
+          label={i18n.t('vote.ending_in') + ' ' + endingInDiffString}>
+          {i18n.t('vote.active_vote')}
+        </Tag>
       )
+    break
 
     case VoteStatus.Upcoming:
-      return (
-        <Tag variant='neutral'>
+      tags.push(
+        <Tag variant='neutral' key='upcoming'>
           {i18n.t('vote.starting_in')} {startingInDiffString}
         </Tag>
       )
+    break
 
     case VoteStatus.Ended:
-      return <Tag variant='warning'>{i18n.t('vote.ended_vote')}</Tag>
+      tags.push(
+        <Tag variant='warning' key='ended'>{i18n.t('vote.ended_vote')}</Tag>
+      )
+    break
 
     case VoteStatus.Paused:
-      return <Tag variant='info'>{i18n.t('vote.paused_vote')}</Tag>
+      tags.push(
+        <Tag variant='info' key='paused'>{i18n.t('vote.paused_vote')}</Tag>
+      )
+    break
 
     case VoteStatus.Canceled:
-      return <Tag variant='error'>{i18n.t('vote.canceled_vote')}</Tag>
-
-    default:
-      return <></>
+      tags.push(
+        <Tag variant='error' key='canceled'>{i18n.t('vote.canceled_vote')}</Tag>
+      )
+    break
   }
 
+  if (archived) {
+    tags.push(
+      <Tag variant='warning' key='archived'>{i18n.t('vote.archived')}</Tag>
+    )
+  }
+
+  return <TagsGroup>{tags}</TagsGroup>
 }
+
+const TagsGroup = styled.div`
+  > span + span {
+    margin-left: 16px;
+  }
+`

--- a/components/blocks/question-results.tsx
+++ b/components/blocks/question-results.tsx
@@ -96,7 +96,7 @@ export const QuestionResults = (props: QuestionsResultsProps) => {
                 {props.results.title.default}
               </Text>
             </Col>
-            {props.question.description &&
+            {props.question?.description &&
               <Col xs={12}>
                 <Text size="sm" color="dark-gray" weight="regular">
                   {props.question.description.default}

--- a/components/elements-v2/tag.tsx
+++ b/components/elements-v2/tag.tsx
@@ -1,9 +1,7 @@
 import { colorsV2 } from '@theme/colors-v2'
-import { theme } from '@theme/global'
 import { ReactNode } from 'react'
-import { colors } from 'react-select/src/theme'
+import { When } from 'react-if'
 import styled from 'styled-components'
-import { Col, Row } from './grid'
 import { Text } from '.'
 
 
@@ -19,20 +17,18 @@ interface ITagProps {
 }
 export const Tag = (props: ITagProps) => {
   return (
-    <Row align='center'>
-      <Col align='center'>
-        <StyledTag {...props}>
-          {props.children}
-        </StyledTag>
-      </Col>
-      {props.label &&
+    <>
+      <StyledTag {...props}>
+        {props.children}
+      </StyledTag>
+      <When condition={!!props.label}>
         <StyledLabel>
           <Text size='xs' weight='medium' color='dark-blue'>
             {props.label}
           </Text>
         </StyledLabel>
-      }
-    </Row>
+      </When>
+    </>
   )
 }
 const cosmeticProps = ['variant', 'size', 'fontWeight', 'label']
@@ -40,22 +36,19 @@ const styledConfig = {
   shouldForwardProp: (prop) => !cosmeticProps.includes(prop)
 }
 
-const StyledTag = styled.div.withConfig(styledConfig)<ITagProps>`
+const StyledTag = styled.span.withConfig(styledConfig)<ITagProps>`
   border-radius: 4px;
   padding: 0px 12px;
   font-family: Manrope;
-  height:${getTagHeigth};
+  line-height:${getTagHeigth};
   font-size:${getTagFontSize};
   font-weight:${getTagFontWeight};
   background:${getTagBackgroundColor};
   color:${getTagColor};
 `
 const StyledLabel = styled.span`
-  // font-family: Manrope;
-  // font-weight: 500;
-  // font-size: 14px;
-  // color: #52606D;
   margin-left: 16px;
+  line-height:${getTagHeigth};
 `
 
 function getTagHeigth(props: ITagProps) {

--- a/components/pages/dashboard/vote-detail/index.tsx
+++ b/components/pages/dashboard/vote-detail/index.tsx
@@ -18,6 +18,7 @@ import { theme } from '@theme/global'
 import moment from 'moment'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Else, If, Then } from 'react-if'
 import styled from 'styled-components'
 import { useUrlHash } from 'use-url-hash'
 import { CopyLinkCard } from './copy-link-card'
@@ -409,50 +410,53 @@ export const ViewDetail = () => {
           <Col xs={12}>
             <Row gutter='md'>
               {/* RESULTS CARD */}
-              {showResultsCard &&
-                <Col xs={12}>
-                  <ExpandableCard
-                    ref={resultsCardRef}
-                    isOpen={isResultsCardOpen}
-                    onButtonClick={handleResultsCardButtonClick}
-                    title={i18n.t("vote_detail.results_card.title")}
-                    icon={<PieChartIcon size={40} />}
-                    buttonProps={{
-                      variant: 'white',
-                      iconRight: { name: 'chevron-up-down', size: 24 },
-                      children: i18n.t("vote_detail.results_card.show")
-                    }}
-                    buttonPropsOpen={{
-                      variant: 'white',
-                      iconRight: { name: 'chevron-up-down', size: 24 },
-                      children: i18n.t("vote_detail.results_card.hide")
-                    }}
-                  >
-                    <ResultsCard />
-                  </ExpandableCard>
-                </Col>
-              }
-              {/* QUESTIONS CARD */}
-              <Col xs={12}>
-                <ExpandableCard
-                  isOpen={isQuestionsCardOpen}
-                  onButtonClick={handleQuestionsCardButtonClick}
-                  title={i18n.t("vote_detail.questions_card.title")}
-                  icon={<QuestionCircleIcon size={40} />}
-                  buttonProps={{
-                    variant: 'white',
-                    iconRight: { name: 'chevron-up-down', size: 24 },
-                    children: i18n.t("vote_detail.results_card.show")
-                  }}
-                  buttonPropsOpen={{
-                    variant: 'white',
-                    iconRight: { name: 'chevron-up-down', size: 24 },
-                    children: i18n.t("vote_detail.results_card.hide")
-                  }}
-                >
-                  <QuestionsCard />
-                </ExpandableCard>
-              </Col>
+              <If condition={showResultsCard}>
+                <Then>
+                  <Col xs={12}>
+                    <ExpandableCard
+                      ref={resultsCardRef}
+                      isOpen={isResultsCardOpen}
+                      onButtonClick={handleResultsCardButtonClick}
+                      title={i18n.t("vote_detail.results_card.title")}
+                      icon={<PieChartIcon size={40} />}
+                      buttonProps={{
+                        variant: 'white',
+                        iconRight: { name: 'chevron-up-down', size: 24 },
+                        children: i18n.t("vote_detail.results_card.show")
+                      }}
+                      buttonPropsOpen={{
+                        variant: 'white',
+                        iconRight: { name: 'chevron-up-down', size: 24 },
+                        children: i18n.t("vote_detail.results_card.hide")
+                      }}
+                    >
+                      <ResultsCard />
+                    </ExpandableCard>
+                  </Col>
+                </Then>
+                <Else>
+                  <Col xs={12}>
+                    <ExpandableCard
+                      isOpen={isQuestionsCardOpen}
+                      onButtonClick={handleQuestionsCardButtonClick}
+                      title={i18n.t("vote_detail.questions_card.title")}
+                      icon={<QuestionCircleIcon size={40} />}
+                      buttonProps={{
+                        variant: 'white',
+                        iconRight: { name: 'chevron-up-down', size: 24 },
+                        children: i18n.t("vote_detail.results_card.show")
+                      }}
+                      buttonPropsOpen={{
+                        variant: 'white',
+                        iconRight: { name: 'chevron-up-down', size: 24 },
+                        children: i18n.t("vote_detail.results_card.hide")
+                      }}
+                    >
+                      <QuestionsCard />
+                    </ExpandableCard>
+                  </Col>
+                </Else>
+              </If>
             </Row>
           </Col>
         </Row>

--- a/components/pages/dashboard/vote-detail/index.tsx
+++ b/components/pages/dashboard/vote-detail/index.tsx
@@ -1,31 +1,28 @@
-import React, { useEffect, useRef, useState } from 'react'
-import styled from 'styled-components'
-import { useTranslation } from 'react-i18next'
+import { ProcessStatusLabel } from '@components/blocks-v2'
+import { Modal } from '@components/blocks-v2/modal'
+import { QuestionsCard } from '@components/blocks-v2/questions-card'
+import { ExpandableCard } from '@components/blocks/expandable-card'
+import { ExpandableContainer } from '@components/blocks/expandable-container'
+import { Button, Card, Col, IColProps, LinkButton, Row, Spacer, Text } from '@components/elements-v2'
+import { DocumentOutlinedIcon, PieChartIcon, QuestionCircleIcon, QuestionOutlinedIcon } from '@components/elements-v2/icons'
+import { ResultsCard } from '@components/pages/pub/votes/components/results-card'
 import { PROCESS_PATH, VOTING_AUTH_FORM_PATH, VOTING_AUTH_LINK_PATH } from '@const/routes'
+import { useMessageAlert } from '@hooks/message-alert'
+import { useProcessWrapper } from '@hooks/use-process-wrapper'
+import { useWallet, WalletRoles } from '@hooks/use-wallet'
+import { useIsMobile } from '@hooks/use-window-size'
 import RouterService from '@lib/router'
 import { VotingType } from '@lib/types'
 import { VoteStatus } from '@lib/util'
-import { useWallet, WalletRoles } from '@hooks/use-wallet'
-import { useMessageAlert } from '@hooks/message-alert'
-import { Button, Card, Spacer } from '@components/elements-v2'
-import { GeneratePdfCard } from './generate-pdf-card-v2'
-import { IColProps, Col, Row, Text, LinkButton } from '@components/elements-v2'
-import { ProcessStatusLabel } from '@components/blocks-v2'
 import { theme } from '@theme/global'
-import { DocumentOutlinedIcon, PieChartIcon, QuestionCircleIcon, QuestionOutlinedIcon } from '@components/elements-v2/icons'
-import { ExpandableContainer } from '@components/blocks/expandable-container'
-import { DetailsCard } from './details-card'
-import { CopyLinkCard } from './copy-link-card'
-import { useProcessWrapper } from '@hooks/use-process-wrapper'
-import { useUrlHash } from 'use-url-hash'
-import { ExpandableCard } from '@components/blocks/expandable-card'
-import { ResultsCard } from '@components/pages/pub/votes/components/results-card'
-import { QuestionsCard } from '@components/blocks-v2/questions-card'
-import { useIsMobile } from '@hooks/use-window-size'
-import { colorsV2 } from '@theme/colors-v2'
-import { Modal } from '@components/blocks-v2/modal'
 import moment from 'moment'
-import { Tag } from '@components/elements-v2/tag'
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+import { useUrlHash } from 'use-url-hash'
+import { CopyLinkCard } from './copy-link-card'
+import { DetailsCard } from './details-card'
+import { GeneratePdfCard } from './generate-pdf-card-v2'
 
 
 export const ViewDetail = () => {
@@ -58,7 +55,6 @@ export const ViewDetail = () => {
     hasEnded,
     methods,
     isAnonymous,
-    archived,
   } = useProcessWrapper(processId)
   const toCalendarFormat = (date: Date) => {
     let momentDate = moment(date).locale('es').format("MMM DD - YYYY (HH:mm)")
@@ -305,11 +301,6 @@ export const ViewDetail = () => {
                   <Col xs={12}>
                     <ProcessStatusLabel />
                   </Col>
-                  { archived &&
-                    <Col xs={12}>
-                      <Tag variant='warning'>Archived</Tag>
-                    </Col>
-                  }
                   <Col xs={12}>
                     <Row gutter='md'>
                       <Col xs={12}>

--- a/components/pages/pub/votes/auth/sign-in-form.tsx
+++ b/components/pages/pub/votes/auth/sign-in-form.tsx
@@ -165,26 +165,25 @@ export const SignInForm = ({
                     />
                   </Col>
                 }
+                <Col xs={12}>
+                  {showError &&
+                    <>
+                      <ErrorDiv>
+                        <ErrorIcon>
+                          <Icon
+                            name='warning'
+                            size={14}
+                            color='#B31B35'
+                          />
+                        </ErrorIcon>
+                        <ErrorText>{i18n.t('vote.credentials_not_accepted')}</ErrorText>
+                      </ErrorDiv>
+                    </>
+                  }
+                </Col>
               </Row>
               <HiddenButton type="submit"></HiddenButton>
             </form>
-            <Col xs={12} md={7}>
-              {/*Error MSG*/}
-              {showError &&
-                <>
-                  <ErrorDiv>
-                    <ErrorIcon>
-                      <Icon
-                        name='warning'
-                        size={14}
-                        color='#B31B35'
-                      />
-                    </ErrorIcon>
-                    <ErrorText>{i18n.t('vote.credentials_not_accepted')}</ErrorText>
-                  </ErrorDiv>
-                </>
-              }
-            </Col>
           </ColWithoutMarginTop>
           <Col xs={12}>
             <Row align='center' justify='center' gutter='xl'>
@@ -240,7 +239,9 @@ const ErrorDiv = styled.div`
   padding: 15px 26px 16px;
   border-radius: 12px;
   margin-top: -15px;
-  margin-right: -20px;
+  flex: 1;
+  display: flex;
+  align-items: center;
 `
 
 const ErrorText = styled.div`
@@ -254,13 +255,7 @@ const ErrorText = styled.div`
 `
 
 const ErrorIcon = styled.div`
-  display:inline;
-  float:left;
-  margin-left:-10px;
-  padding-top: 10px;
-  @media ${({ theme }) => theme.screenMax.mobileL} {
-    svg {
-      margin-top: 8px;
-    }
-  }
+  display: inline;
+  float: left;
+  margin-left: -10px;
 `

--- a/components/pages/pub/votes/auth/sign-in-form.tsx
+++ b/components/pages/pub/votes/auth/sign-in-form.tsx
@@ -1,33 +1,28 @@
-import React, { ChangeEvent, useState, useEffect } from 'react'
-import styled from 'styled-components'
-import { ProcessDetails, EntityMetadata } from 'dvote-js'
-import { useTranslation } from 'react-i18next'
-import { useBlockHeight } from '@vocdoni/react-hooks'
-
+import { CardImageHeader } from '@components/blocks/card/image-header'
 import {
-  Fieldset,
   FormGroupVariant,
   InputFormGroup,
-  InputPasswordFormGroup,
+  InputPasswordFormGroup
 } from '@components/blocks/form'
-import { Column } from '@components/elements/grid'
+import { Col, Row, Text } from '@components/elements-v2'
+import { Icon } from '@components/elements-v2/icons'
 import { Button } from '@components/elements/button'
 import { SignInFormCard } from '@components/elements/cards'
-import { FlexContainer, FlexJustifyContent } from '@components/elements/flex'
-import { CardImageHeader } from '@components/blocks/card/image-header'
-import { FormFieldsetContainer } from '../components/form-fieldset-container'
-import { Col, Input, Row, Text } from '@components/elements-v2'
-import { useProcessWrapper } from '@hooks/use-process-wrapper'
-import { useUrlHash } from "use-url-hash"
-import { VoteStatus } from '@lib/util'
-import moment from 'moment'
-import { Icon } from '@components/elements-v2/icons'
 import { PreregisteredRedirectModal } from '@components/pages/pub/votes/components/preregistered-redirect-modal'
-import { useWallet, WalletRoles } from '@hooks/use-wallet'
-import { useVoting } from '@hooks/use-voting'
-import { useRouter } from 'next/router'
 import { PROCESS_PATH } from '@const/routes'
+import { useProcessWrapper } from '@hooks/use-process-wrapper'
+import { useVoting } from '@hooks/use-voting'
+import { useWallet, WalletRoles } from '@hooks/use-wallet'
 import RouterService from '@lib/router'
+import { VoteStatus } from '@lib/util'
+import { useBlockHeight } from '@vocdoni/react-hooks'
+import { EntityMetadata, ProcessDetails } from 'dvote-js'
+import moment from 'moment'
+import { useRouter } from 'next/router'
+import React, { ChangeEvent, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+import { useUrlHash } from "use-url-hash"
 
 
 interface IFieldValues {
@@ -76,6 +71,7 @@ export const SignInForm = ({
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault()
     onSubmit()
+    setSameInput(true)
   }
   const [isRedirectModalOpen, setIsRedirectModalOpen] = useState<boolean>(false)
   const { setWallet } = useWallet({ role: WalletRoles.VOTER })

--- a/components/pages/pub/votes/preregister-view.tsx
+++ b/components/pages/pub/votes/preregister-view.tsx
@@ -1,22 +1,22 @@
-import React, { useEffect, useState } from 'react'
-import styled from 'styled-components'
-import { SignInFormCard } from '@components/elements/cards'
-import { EntityMetadata, ProcessDetails, VotingApi } from 'dvote-js'
-import { useTranslation } from 'react-i18next'
-import { CardImageHeader } from '@components/blocks/card'
-import { FormFieldsetContainer } from './components/form-fieldset-container'
-import { InputPasswordFormGroup } from '@components/blocks/form'
-import { checkStrength } from '@lib/util'
-import { Typography, TypographyVariant } from '@components/elements/typography'
-import { useBlockStatus } from '@vocdoni/react-hooks'
 import { Banner, BannerSize, BannerVariant } from '@components/blocks/banner_v2'
-import { FlexContainer, FlexJustifyContent } from '@components/elements/flex'
-import { ImageContainer } from '@components/elements/images'
-import { colors } from '@theme/colors'
+import { CardImageHeader } from '@components/blocks/card'
+import { InputPasswordFormGroup } from '@components/blocks/form'
 import { PasswordFeedbackSuccess } from '@components/blocks/password-feedback-success'
 import { Button } from '@components/elements/button'
+import { SignInFormCard } from '@components/elements/cards'
+import { FlexContainer, FlexJustifyContent } from '@components/elements/flex'
+import { ImageContainer } from '@components/elements/images'
+import { Typography, TypographyVariant } from '@components/elements/typography'
+import { checkStrength } from '@lib/util'
+import { colors } from '@theme/colors'
+import { useBlockStatus } from '@vocdoni/react-hooks'
+import { EntityMetadata, ProcessDetails, VotingApi } from 'dvote-js'
 import moment from 'moment'
 import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+import { FormFieldsetContainer } from './components/form-fieldset-container'
 
 export enum PreregisterFormFields {
   Password = 'password',
@@ -141,7 +141,7 @@ export const PreregisterView = ({
           <InputPasswordFormGroup
             label={i18n.t('votes.preregister_view.password')}
             placeholder={i18n.t('votes.preregister_view.insert_password')}
-            info={errorPassword}
+            error={errorPassword}
             value={values.password}
             name={PreregisterFormFields.Password}
             onChange={handleChangePassword}
@@ -150,7 +150,7 @@ export const PreregisterView = ({
           <InputPasswordFormGroup
             label={i18n.t('votes.preregister_view.repeat')}
             placeholder={i18n.t('votes.preregister_view.insert_password_again')}
-            success={passwordMatch && <PasswordFeedbackSuccess />}
+            success={!errorPassword && passwordMatch && <PasswordFeedbackSuccess />}
             value={values.passwordConfirm}
             name={PreregisterFormFields.PasswordConfirm}
             onChange={handleChangePassword}

--- a/i18n/locales/ca.json
+++ b/i18n/locales/ca.json
@@ -623,7 +623,7 @@
         "creating_census": "Creant cens",
         "creating_process": "Creant procés",
         "creation": "Creació",
-        "credentials_not_accepted": "Credencials no vàlides. Posa't amb contacte amb l'entitat.",
+        "credentials_not_accepted": "Credencials no vàlides. Posa't en contacte amb l'entitat.",
         "define_the_timeframe_of_the_proposal": "Definició del termini del procés de votació",
         "delete_option": "Elimina aquesta opció",
         "delete_question": "Elimina aquesta pregunta",

--- a/i18n/locales/ca.json
+++ b/i18n/locales/ca.json
@@ -579,6 +579,7 @@
         "active_vote": "Procés actiu",
         "add_new_question": "Afegeix una nova pregunta",
         "add_option": "Afegeix una altra opció",
+        "archived": "Arxivat",
         "auth": {
             "auth_button": "Autenticar-se",
             "close_preregister_redirect_modal": "Anar a la pàgina de votació",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -579,6 +579,7 @@
         "active_vote": "Active vote",
         "add_new_question": "Add a question",
         "add_option": "Add an option",
+        "archived": "Archived",
         "auth": {
             "auth_button": "Authenticate",
             "close_preregister_redirect_modal": "Go to voting process",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -579,6 +579,7 @@
         "active_vote": "Proceso activo",
         "add_new_question": "Añade una nueva pregunta",
         "add_option": "Añade más opciones",
+        "archived": "Archivado",
         "auth": {
             "auth_button": "Autenticarse",
             "close_preregister_redirect_modal": "Ir a la página de votación",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,16 +17,16 @@
         "@vocdoni/census": "~1.16.0",
         "@vocdoni/client": "~1.16.6",
         "@vocdoni/common": "^1.15.3",
-        "@vocdoni/react-hooks": "~0.13.1",
+        "@vocdoni/react-hooks": "0.15.0",
         "@vocdoni/signing": "~1.16.2",
-        "@vocdoni/voting": "~1.16.1",
+        "@vocdoni/voting": "~1.16.4",
         "@vocdoni/wallets": "~1.16.0",
         "blob-stream": "^0.1.3",
         "bluebird": "^3.7.2",
         "brfs": "^2.0.2",
         "copy-to-clipboard": "^3.3.1",
         "dexie": "^3.0.3",
-        "dvote-js": "1.16.1",
+        "dvote-js": "1.16.2",
         "ethers": "^5.5.0",
         "filesize": "^6.2.2",
         "hamburger-react": "^2.4.0",
@@ -7097,13 +7097,13 @@
       }
     },
     "node_modules/@vocdoni/react-hooks": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@vocdoni/react-hooks/-/react-hooks-0.13.1.tgz",
-      "integrity": "sha512-vIC2k2/8tlFuUNlylzozUuPQWtgx2tfzU+3O4RuCs8Xxw+lvxUWv02pkTD8WZE/+AZPsdQooPnKUus05/fVsDA==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@vocdoni/react-hooks/-/react-hooks-0.15.0.tgz",
+      "integrity": "sha512-v2dkczzwm5568Nb+zvxK+qJrDM5+abEXSD72i1P+roz+R3ubPCDgca3/DhbLxo6X+Ign59ZWpdsjMePn5u03qQ==",
       "dependencies": {
-        "@vocdoni/client": "^1.15.1",
+        "@vocdoni/client": "^1.16.5",
         "@vocdoni/common": "^1.15.1",
-        "@vocdoni/voting": "^1.15.5"
+        "@vocdoni/voting": "^1.16.3"
       },
       "engines": {
         "node": ">=14"
@@ -7141,16 +7141,16 @@
       }
     },
     "node_modules/@vocdoni/voting": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/@vocdoni/voting/-/voting-1.16.3.tgz",
-      "integrity": "sha512-IySRylc+TWKWJE7dZTb7RZS5akc2qkoso7zPfkoGIRHkwL3a2Q4pDD1GcGRQ0Cv6TA7Ujgnm/9gow5QJDFeA2Q==",
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/@vocdoni/voting/-/voting-1.16.4.tgz",
+      "integrity": "sha512-C7CF+x//G+bKAz+hXfNl6mBN/z0ZKZ96zBX4jv9ehDHrOOF9bkcHIWcrtSNl6BK834hr0tNqC/txlWzFz/QX7w==",
       "dependencies": {
-        "@vocdoni/client": "^1.16.5",
+        "@vocdoni/client": "^1.16.6",
         "@vocdoni/common": "^1.15.1",
         "@vocdoni/contract-wrappers": "^1.15.0",
         "@vocdoni/data-models": "^1.15.3",
         "@vocdoni/hashing": "^1.15.0",
-        "@vocdoni/signing": "^1.16.1",
+        "@vocdoni/signing": "^1.16.2",
         "buffer": "^6.0.3"
       }
     },
@@ -11861,19 +11861,18 @@
       }
     },
     "node_modules/dvote-js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/dvote-js/-/dvote-js-1.16.1.tgz",
-      "integrity": "sha512-+GyIl0B+x0m2m6o7jDPr7ejEnVXr51So40IkWGTi9w68pYFxQOjzDlZmf3M/hUO9F4jW0onRqFQNWmZf4LGNYQ==",
-      "hasInstallScript": true,
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/dvote-js/-/dvote-js-1.16.2.tgz",
+      "integrity": "sha512-a+/8uVpEeVaKcOzxItcsFrcpsMQLeLfTJFdQ2rAe5VT1TtGOM4nTNYMhZscKwAhQ3MJR8vsViuYvbykA0ig70Q==",
       "dependencies": {
         "@vocdoni/census": "^1.16.0",
-        "@vocdoni/client": "^1.16.0",
-        "@vocdoni/common": "^1.15.1",
+        "@vocdoni/client": "^1.16.7",
+        "@vocdoni/common": "^1.15.3",
         "@vocdoni/contract-wrappers": "^1.15.0",
         "@vocdoni/data-models": "^1.15.3",
         "@vocdoni/encryption": "^1.14.1",
         "@vocdoni/hashing": "^1.15.0",
-        "@vocdoni/signing": "^1.16.0",
+        "@vocdoni/signing": "^1.16.2",
         "@vocdoni/voting": "^1.16.1",
         "@vocdoni/wallets": "^1.16.0"
       }
@@ -32245,13 +32244,13 @@
       }
     },
     "@vocdoni/react-hooks": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@vocdoni/react-hooks/-/react-hooks-0.13.1.tgz",
-      "integrity": "sha512-vIC2k2/8tlFuUNlylzozUuPQWtgx2tfzU+3O4RuCs8Xxw+lvxUWv02pkTD8WZE/+AZPsdQooPnKUus05/fVsDA==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@vocdoni/react-hooks/-/react-hooks-0.15.0.tgz",
+      "integrity": "sha512-v2dkczzwm5568Nb+zvxK+qJrDM5+abEXSD72i1P+roz+R3ubPCDgca3/DhbLxo6X+Ign59ZWpdsjMePn5u03qQ==",
       "requires": {
-        "@vocdoni/client": "^1.15.1",
+        "@vocdoni/client": "^1.16.5",
         "@vocdoni/common": "^1.15.1",
-        "@vocdoni/voting": "^1.15.5"
+        "@vocdoni/voting": "^1.16.3"
       }
     },
     "@vocdoni/signing": {
@@ -32282,16 +32281,16 @@
       }
     },
     "@vocdoni/voting": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/@vocdoni/voting/-/voting-1.16.3.tgz",
-      "integrity": "sha512-IySRylc+TWKWJE7dZTb7RZS5akc2qkoso7zPfkoGIRHkwL3a2Q4pDD1GcGRQ0Cv6TA7Ujgnm/9gow5QJDFeA2Q==",
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/@vocdoni/voting/-/voting-1.16.4.tgz",
+      "integrity": "sha512-C7CF+x//G+bKAz+hXfNl6mBN/z0ZKZ96zBX4jv9ehDHrOOF9bkcHIWcrtSNl6BK834hr0tNqC/txlWzFz/QX7w==",
       "requires": {
-        "@vocdoni/client": "^1.16.5",
+        "@vocdoni/client": "^1.16.6",
         "@vocdoni/common": "^1.15.1",
         "@vocdoni/contract-wrappers": "^1.15.0",
         "@vocdoni/data-models": "^1.15.3",
         "@vocdoni/hashing": "^1.15.0",
-        "@vocdoni/signing": "^1.16.1",
+        "@vocdoni/signing": "^1.16.2",
         "buffer": "^6.0.3"
       }
     },
@@ -36060,18 +36059,18 @@
       }
     },
     "dvote-js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/dvote-js/-/dvote-js-1.16.1.tgz",
-      "integrity": "sha512-+GyIl0B+x0m2m6o7jDPr7ejEnVXr51So40IkWGTi9w68pYFxQOjzDlZmf3M/hUO9F4jW0onRqFQNWmZf4LGNYQ==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/dvote-js/-/dvote-js-1.16.2.tgz",
+      "integrity": "sha512-a+/8uVpEeVaKcOzxItcsFrcpsMQLeLfTJFdQ2rAe5VT1TtGOM4nTNYMhZscKwAhQ3MJR8vsViuYvbykA0ig70Q==",
       "requires": {
         "@vocdoni/census": "^1.16.0",
-        "@vocdoni/client": "^1.16.0",
-        "@vocdoni/common": "^1.15.1",
+        "@vocdoni/client": "^1.16.7",
+        "@vocdoni/common": "^1.15.3",
         "@vocdoni/contract-wrappers": "^1.15.0",
         "@vocdoni/data-models": "^1.15.3",
         "@vocdoni/encryption": "^1.14.1",
         "@vocdoni/hashing": "^1.15.0",
-        "@vocdoni/signing": "^1.16.0",
+        "@vocdoni/signing": "^1.16.2",
         "@vocdoni/voting": "^1.16.1",
         "@vocdoni/wallets": "^1.16.0"
       }


### PR DESCRIPTION
What's done so far:

- Fix DVOT-526. Show process tags inline instead of in new lines.
- Done DVOT-527. Hide "voting questions" component when results are already visible
- Done DVOT-528. Do not show success message on preregister password field if password has errors. Also, show error in read, instead than like a simple info message.
- Fix error message in process login page not being shown when using enter key (but was shown when clicking the button)
- Fix error message style not fitting its container.
- Translate "Archived" tag
- Update `package-lock.json` file to be in sync with `package.json` file