### PR TITLE
Fix version for html-sanitize, since it's causing the build to fail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "react-svg-spinner": "^1.0.4",
         "recoil": "^0.4.0",
         "remixicon": "^2.5.0",
-        "sanitize-html": "^2.4.0",
+        "sanitize-html": "2.7.3",
         "styled-components": "^5.3.0",
         "token-amount": "^0.3.0",
         "turndown": "^7.1.1",
@@ -22310,9 +22310,9 @@
       }
     },
     "node_modules/sanitize-html": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.1.tgz",
-      "integrity": "sha512-oOpe8l4J8CaBk++2haoN5yNI5beekjuHv3JRPKUx/7h40Rdr85pemn4NkvUB3TcBP7yjat574sPlcMAyv4UQig==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.3.tgz",
+      "integrity": "sha512-jMaHG29ak4miiJ8wgqA1849iInqORgNv7SLfSw9LtfOhEUQ1C0YHKH73R+hgyufBW9ZFeJrb057k9hjlfBCVlw==",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
@@ -44255,9 +44255,9 @@
       }
     },
     "sanitize-html": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.1.tgz",
-      "integrity": "sha512-oOpe8l4J8CaBk++2haoN5yNI5beekjuHv3JRPKUx/7h40Rdr85pemn4NkvUB3TcBP7yjat574sPlcMAyv4UQig==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.3.tgz",
+      "integrity": "sha512-jMaHG29ak4miiJ8wgqA1849iInqORgNv7SLfSw9LtfOhEUQ1C0YHKH73R+hgyufBW9ZFeJrb057k9hjlfBCVlw==",
       "requires": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-svg-spinner": "^1.0.4",
     "recoil": "^0.4.0",
     "remixicon": "^2.5.0",
-    "sanitize-html": "^2.4.0",
+    "sanitize-html": "2.7.3",
     "styled-components": "^5.3.0",
     "token-amount": "^0.3.0",
     "turndown": "^7.1.1",


### PR DESCRIPTION
Fixed version of `html-sanitize` package to `2.7.3`, coming from `^2.4.0` (which resulted in a recent upgrade to 2.8.0, and that causes a dependency issue).